### PR TITLE
Remove the plugin that allows co-locating document definitions with react components

### DIFF
--- a/.changeset/yellow-bobcats-report.md
+++ b/.changeset/yellow-bobcats-report.md
@@ -1,0 +1,6 @@
+---
+'markdownlayer': minor
+---
+
+Remove the plugin that allows co-locating document definitions with react components.
+This is behaviour is not encouraged.

--- a/packages/markdownlayer/src/core/generation/config-file.ts
+++ b/packages/markdownlayer/src/core/generation/config-file.ts
@@ -85,7 +85,7 @@ export async function getConfig(options: GetConfigOptions): Promise<GetConfigRes
     logLevel: 'silent',
     metafile: true,
     absWorkingDir: cwd,
-    plugins: [markdownlayerGenPlugin(), makeAllPackagesExternalPlugin(configPath)],
+    plugins: [makeAllPackagesExternalPlugin(configPath)],
   };
 
   // Build the configuration file
@@ -129,26 +129,6 @@ export async function getConfig(options: GetConfigOptions): Promise<GetConfigRes
     configPath: configPath,
     configHash: esbuildHash,
     config: exports.default as MarkdownlayerConfig,
-  };
-}
-
-/**
- * This esbuild plugin is needed in some cases where users import code that imports from '.markdownlayer/*'
- * (e.g. when co-locating document type definitions with React components).
- */
-function markdownlayerGenPlugin(): esbuild.Plugin {
-  return {
-    name: 'markdownlayer-gen',
-    setup(build) {
-      build.onResolve({ filter: /markdownlayer\/generated/ }, (args) => ({
-        path: args.path,
-        namespace: 'markdownlayer-gen',
-      }));
-
-      build.onLoad({ filter: /.*/, namespace: 'markdownlayer-gen' }, () => ({
-        contents: '// empty',
-      }));
-    },
   };
 }
 


### PR DESCRIPTION
This is behaviour is not encouraged.