### PR TITLE
Include version in the data cache path to ensure generations do not cross dev/prod boundaries

### DIFF
--- a/.changeset/small-pears-march.md
+++ b/.changeset/small-pears-march.md
@@ -1,0 +1,8 @@
+---
+'markdownlayer': minor
+---
+
+Include version in the data cache path to ensure generations do not cross dev/prod boundaries. This is useful in two scenarios:
+
+1. Local dev and build when one forgets to remove the `.markdownlayer` folder.
+2. When the `.markdownlayer` folder is cached such as in a CI build.

--- a/packages/markdownlayer/src/core/generation/index.ts
+++ b/packages/markdownlayer/src/core/generation/index.ts
@@ -137,8 +137,8 @@ async function generateInner(options: GenerateInnerOptions) {
   let outputFolder = options.outputFolder;
 
   // load cache from file if it exists, otherwise create a new cache
-  // changes in configuration options and plugins will invalidate the cache
-  const cacheFilePath = path.join(outputFolder, `cache/v${version}/data-${configHash}.json`);
+  // changes in mode, version, configuration options, plugins will invalidate the cache
+  const cacheFilePath = path.join(outputFolder, `cache/${mode}/v${version}/data-${configHash}.json`);
   let cache: DataCache = { items: {} };
   if (caching && fs.existsSync(cacheFilePath)) {
     cache = JSON.parse(fs.readFileSync(cacheFilePath, 'utf8'));


### PR DESCRIPTION
This is useful in two scenarios:
1. Local dev and build when one forgets to remove the `.markdownlayer` folder.
2. When the `.markdownlayer` folder is cached such as in a CI build.