### PR TITLE
Infer types from config file by reference instead of generating them.

### DIFF
--- a/.changeset/five-buckets-shave.md
+++ b/.changeset/five-buckets-shave.md
@@ -1,0 +1,6 @@
+---
+'markdownlayer': minor
+---
+
+Infer types from config file by reference instead of generating them.
+This improves the dev experience because changes in schema reflect instantly instead of waiting for a fresh build.

--- a/examples/starter/markdownlayer.config.ts
+++ b/examples/starter/markdownlayer.config.ts
@@ -1,9 +1,9 @@
-import type { MarkdownlayerConfig } from 'markdownlayer/core';
+import { defineConfig } from 'markdownlayer/core';
 import rehypeSlug from 'rehype-slug';
 import { z } from 'zod';
 import { rehypeAutolinkHeadings, rehypePrettyCode } from './src/markdownlayer';
 
-const markdownConfig: MarkdownlayerConfig = {
+export default defineConfig({
   contentDirPath: './src/content',
   definitions: {
     legal: {
@@ -74,6 +74,4 @@ const markdownConfig: MarkdownlayerConfig = {
   },
   remarkPlugins: [],
   rehypePlugins: [rehypeSlug, rehypeAutolinkHeadings, rehypePrettyCode],
-};
-
-export default markdownConfig;
+});

--- a/packages/markdownlayer/package.json
+++ b/packages/markdownlayer/package.json
@@ -68,8 +68,7 @@
     "remark-gfm": "4.0.0",
     "shelljs": "0.8.5",
     "source-map-support": "0.5.21",
-    "zod": "3.23.8",
-    "zod-to-ts": "1.2.0"
+    "zod": "3.23.8"
   },
   "devDependencies": {
     "@types/estree": "1.0.5",

--- a/packages/markdownlayer/src/core/generation/config-file.ts
+++ b/packages/markdownlayer/src/core/generation/config-file.ts
@@ -29,7 +29,7 @@ export type GetConfigOptions = {
 /** Represents the result of getting the configuration. */
 export type GetConfigResult = {
   /** The path to the configuration file. */
-  configPath?: string;
+  configPath: string;
 
   /**
    * The hash of the configuration.

--- a/packages/markdownlayer/src/core/types.ts
+++ b/packages/markdownlayer/src/core/types.ts
@@ -168,7 +168,7 @@ export type BaseDoc = DocumentMeta & {
   tableOfContents?: TocItem[];
 };
 
-export interface DocumentDefinitionGitOptions {
+export type DocumentDefinitionGitOptions = {
   /**
    * Whether to use last update information from git commit history.
    *
@@ -200,12 +200,12 @@ export interface DocumentDefinitionGitOptions {
    * @default false
    */
   authors?: boolean;
-}
+};
 
 /**
  * Represents the definition of a document.
  */
-export interface DocumentDefinition {
+export type DocumentDefinition = {
   /**
    * Format of contents of the files
    * - `detect`: Detects the format based on the file extension
@@ -255,7 +255,7 @@ export interface DocumentDefinition {
    * @param document The document to validate
    */
   validate?: (document: BaseDoc) => Promise<void>;
-}
+};
 
 export type MarkdownlayerConfigPlugins = {
   /** Options for using markdoc. */
@@ -328,7 +328,9 @@ export type MarkdownlayerConfigMarkdoc = {
   transformConfig?: MarkdocConfig;
 };
 
-export type MarkdownlayerConfig = {
+export type DocumentDefinitions = { [type: string]: DocumentDefinition };
+
+export type MarkdownlayerConfig<T extends DocumentDefinitions = DocumentDefinitions> = {
   /**
    * Whether to cache the generated documents.
    * This is useful for development mode to speed up HMR.
@@ -361,7 +363,7 @@ export type MarkdownlayerConfig = {
    * Definitions of documents to generate.
    * The key is the type of the document and should match your documents directory name in `contentDirPath`.
    */
-  definitions: Record<string, DocumentDefinition>;
+  definitions: T;
 
   /**
    * Whether to use mdoc for `.md` files instead of mdx.
@@ -371,3 +373,10 @@ export type MarkdownlayerConfig = {
    */
   mdAsMarkdoc?: boolean;
 } & MarkdownlayerConfigPlugins;
+
+/**
+ * Define config (identity function for type inference)
+ */
+export function defineConfig<T extends DocumentDefinitions>(config: MarkdownlayerConfig<T>): MarkdownlayerConfig<T> {
+  return config;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,9 +204,6 @@ importers:
       zod:
         specifier: 3.23.8
         version: 3.23.8
-      zod-to-ts:
-        specifier: 1.2.0
-        version: 1.2.0(typescript@5.5.3)(zod@3.23.8)
     devDependencies:
       '@types/estree':
         specifier: 1.0.5
@@ -3902,12 +3899,6 @@ packages:
   yocto-queue@1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
-
-  zod-to-ts@1.2.0:
-    resolution: {integrity: sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==}
-    peerDependencies:
-      typescript: ^4.9.4 || ^5.0.2
-      zod: ^3
 
   zod@3.23.8:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
@@ -8232,11 +8223,6 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.0.0: {}
-
-  zod-to-ts@1.2.0(typescript@5.5.3)(zod@3.23.8):
-    dependencies:
-      typescript: 5.5.3
-      zod: 3.23.8
 
   zod@3.23.8: {}
 


### PR DESCRIPTION
This improves the dev experience because changes in schema reflect instantly instead of waiting for a fresh build.