### PR TITLE
Move `format` from `DocumentDefinition` and `mdAsMarkdoc` from the config to the body schema.

### DIFF
--- a/.changeset/wise-points-nail.md
+++ b/.changeset/wise-points-nail.md
@@ -1,0 +1,6 @@
+---
+'markdownlayer': minor
+---
+
+Move `format` from `DocumentDefinition` and `mdAsMarkdoc` from the config to the body schema.
+This allows setting `mdAdMarkdoc` per definition.

--- a/packages/markdownlayer/src/generate.ts
+++ b/packages/markdownlayer/src/generate.ts
@@ -111,7 +111,7 @@ async function generateInner(config: ResolvedConfig) {
 
 type GenerateDocsOptions = DocumentDefinition & { type: string; config: ResolvedConfig };
 async function generateDocuments(options: GenerateDocsOptions): Promise<GeneratedCount> {
-  const { type, format, config } = options;
+  const { type, config } = options;
   const { contentDirPath, patterns = '**/*.{md,mdoc,mdx}', cache, output } = config;
 
   // ensure that all definitions have at least one pattern
@@ -155,7 +155,6 @@ async function generateDocuments(options: GenerateDocsOptions): Promise<Generate
     let data: Record<string, unknown> = frontmatter;
     const resolveSchemaOptions: ResolveSchemaOptions = {
       type,
-      format,
       schema: options.schema,
 
       path: file,

--- a/packages/markdownlayer/src/schemas/body.ts
+++ b/packages/markdownlayer/src/schemas/body.ts
@@ -1,9 +1,30 @@
 import { extname } from 'node:path';
 import { custom } from 'zod';
 import { bundle, type BundleProps } from '../bundle';
-import type { DocumentBody, DocumentDefinition, DocumentFormat, DocumentFormatInput, ResolvedConfig } from '../types';
+import type { DocumentBody, DocumentFormat, DocumentFormatInput, ResolvedConfig } from '../types';
 
-type Options = Pick<DocumentDefinition, 'format'> & {
+export type BodyOptions = {
+  /**
+   * Format of contents of the files
+   * - `detect`: Detects the format based on the file extension
+   * - `md`: Markdown
+   * - `mdx`: Markdown with JSX
+   * - `mdoc`: Markdoc
+   *
+   * @default 'detect'
+   */
+  format?: DocumentFormatInput;
+
+  /**
+   * Whether to use mdoc for `.md` files instead of mdx.
+   * This is useful for when you want to use mdx for `.mdx` files but not for `.md` files.
+   *
+   * @default false
+   */
+  mdAsMarkdoc?: boolean;
+};
+
+type Options = BodyOptions & {
   path: string;
   contents: string;
   frontmatter: Record<string, unknown>;
@@ -18,13 +39,13 @@ export function body({
   // output,
   path,
   format: formatInput = 'detect',
+  mdAsMarkdoc = false,
   contents,
   frontmatter,
   config,
 }: Options) {
   return custom().transform<DocumentBody>(async (value, { addIssue }) => {
     // determine the document format
-    const { mdAsMarkdoc = false } = config;
     let format = getFormat({ file: path, format: formatInput });
     if (format === 'md' && mdAsMarkdoc) format = 'mdoc';
 

--- a/packages/markdownlayer/src/schemas/resolve.ts
+++ b/packages/markdownlayer/src/schemas/resolve.ts
@@ -1,5 +1,5 @@
 import type { DocumentDefinition, ResolvedConfig } from '../types';
-import { body } from './body';
+import { type BodyOptions, body } from './body';
 import { type GitParams, git } from './git';
 import { id } from './id';
 import { type ImageOptions, image } from './image';
@@ -12,7 +12,7 @@ export type SchemaContext = {
    * Schema for a document's body.
    * @returns A Zod object representing a document body.
    */
-  body: () => ReturnType<typeof body>;
+  body: (params?: BodyOptions) => ReturnType<typeof body>;
 
   /**
    * Schema for a file's git file info.
@@ -60,7 +60,7 @@ export type SchemaContext = {
   toc: () => ReturnType<typeof toc>;
 };
 
-export type ResolveSchemaOptions = Pick<DocumentDefinition, 'format' | 'schema'> & {
+export type ResolveSchemaOptions = Pick<DocumentDefinition, 'schema'> & {
   config: ResolvedConfig;
   /** Type of definition */
   type: string;
@@ -71,7 +71,6 @@ export type ResolveSchemaOptions = Pick<DocumentDefinition, 'format' | 'schema'>
 
 export function resolveSchema({
   type,
-  format,
   schema,
 
   path,
@@ -82,7 +81,7 @@ export function resolveSchema({
 }: ResolveSchemaOptions) {
   if (typeof schema === 'function') {
     schema = schema({
-      body: () => body({ contents, path, frontmatter, format, config }),
+      body: (params: BodyOptions = {}) => body({ ...params, path, contents, frontmatter, config }),
       git: (params: GitParams = {}) => git({ ...params, path }),
       id: () => id({ type, path, config }),
       image: (params: ImageOptions = {}) => image({ ...params, path, config }),

--- a/packages/markdownlayer/src/types.ts
+++ b/packages/markdownlayer/src/types.ts
@@ -89,17 +89,6 @@ export type TocItem = {
 /** Represents the definition of a document collection. */
 export type DocumentDefinition = {
   /**
-   * Format of contents of the files
-   * - `detect`: Detects the format based on the file extension
-   * - `md`: Markdown
-   * - `mdx`: Markdown with JSX
-   * - `mdoc`: Markdoc
-   *
-   * @default 'detect'
-   */
-  format?: DocumentFormatInput;
-
-  /**
    * Schema for each document in the collection.
    */
   schema: DocumentDefinitionSchema | ((context: SchemaContext) => DocumentDefinitionSchema);
@@ -244,14 +233,6 @@ export type MarkdownlayerConfig<T extends DocumentDefinitions = DocumentDefiniti
 
   /** Output configuration */
   output?: MarkdownlayerConfigOutput;
-
-  /**
-   * Whether to use mdoc for `.md` files instead of mdx.
-   * This is useful for when you want to use mdx for `.mdx` files but not for `.md` files.
-   *
-   * @default false
-   */
-  mdAsMarkdoc?: boolean;
 } & MarkdownlayerConfigPlugins;
 
 /**


### PR DESCRIPTION
This allows setting `mdAdMarkdoc` per definition.