### PR TITLE
Restore support for CJS.

### DIFF
--- a/.changeset/shy-beers-suffer.md
+++ b/.changeset/shy-beers-suffer.md
@@ -1,0 +1,7 @@
+---
+'markdownlayer': minor
+---
+
+Restore support for CJS.
+This solves some issues in NextJS config files.
+Setting `"type": "module"` in applications is no longer required.

--- a/examples/starter/next.config.js
+++ b/examples/starter/next.config.js
@@ -1,4 +1,4 @@
-import { withMarkdownlayer } from 'markdownlayer';
+const { withMarkdownlayer } = require('markdownlayer');
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -8,4 +8,4 @@ const nextConfig = {
   },
 };
 
-export default withMarkdownlayer(nextConfig);
+module.defaults = withMarkdownlayer(nextConfig);

--- a/examples/starter/package.json
+++ b/examples/starter/package.json
@@ -2,7 +2,6 @@
   "name": "starter",
   "version": "0.0.1",
   "private": true,
-  "type": "module",
   "scripts": {
     "dev": "next dev --turbo",
     "build": "next build",

--- a/packages/markdownlayer/package.json
+++ b/packages/markdownlayer/package.json
@@ -2,18 +2,23 @@
   "name": "markdownlayer",
   "version": "0.4.0-beta.12",
   "type": "module",
+  "main": "dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
       "types": "./dist/index.d.ts"
     },
     "./react": {
       "import": "./dist/react/index.js",
+      "require": "./dist/react/index.cjs",
       "types": "./dist/react/index.d.ts"
     },
     "./remark": {
       "import": "./dist/remark/index.js",
+      "require": "./dist/remark/index.cjs",
       "types": "./dist/remark/index.d.ts"
     }
   },

--- a/packages/markdownlayer/src/bundle.ts
+++ b/packages/markdownlayer/src/bundle.ts
@@ -1,14 +1,9 @@
 import { globalExternals } from '@fal-works/esbuild-plugin-global-externals';
 import Markdoc, { type Config as MarkdocConfig } from '@markdoc/markdoc';
 import type { Options as CompileOptions } from '@mdx-js/esbuild';
-import mdxESBuild from '@mdx-js/esbuild';
 import type { BuildOptions, Plugin } from 'esbuild';
 import esbuild, { type Message } from 'esbuild';
-import rehypeRaw, { type Options as RehypeRawOptions } from 'rehype-raw';
-import remarkDirective from 'remark-directive';
-import remarkEmoji from 'remark-emoji';
-import remarkFrontmatter from 'remark-frontmatter';
-import remarkGfm from 'remark-gfm';
+import type { Options as RehypeRawOptions } from 'rehype-raw';
 import type { Pluggable, PluggableList } from 'unified';
 
 import { remarkAdmonitions, remarkHeadings, remarkTransformImages, remarkTransformLinks } from './remark';
@@ -88,6 +83,12 @@ async function mdx({ config, path, contents, format }: BundleMdxProps): Promise<
     remarkRehypeOptions,
   } = config;
 
+  const { default: mdxESBuild } = await import('@mdx-js/esbuild');
+  const { default: remarkEmoji } = await import('remark-emoji');
+  const { default: remarkDirective } = await import('remark-directive');
+  const { default: remarkFrontmatter } = await import('remark-frontmatter');
+  const { default: remarkGfm } = await import('remark-gfm');
+
   const compileOptions: CompileOptions = {
     format,
     recmaPlugins,
@@ -118,6 +119,8 @@ async function mdx({ config, path, contents, format }: BundleMdxProps): Promise<
   };
 
   if (format === 'md') {
+    const { default: rehypeRaw } = await import('rehype-raw');
+
     // This is what permits to embed HTML elements with format 'md'
     // See https://github.com/facebook/docusaurus/pull/8960
     // See https://github.com/mdx-js/mdx/pull/2295#issuecomment-1540085960

--- a/packages/markdownlayer/src/generate.ts
+++ b/packages/markdownlayer/src/generate.ts
@@ -1,5 +1,4 @@
 import chokidar from 'chokidar';
-import { globby } from 'globby';
 import matter from 'gray-matter';
 import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { join, relative } from 'node:path';
@@ -120,6 +119,7 @@ async function generateDocuments(options: GenerateDocsOptions): Promise<Generate
 
   // find the files
   const definitionDir = join(contentDirPath, type);
+  const { globby } = await import('globby');
   const files = await globby(patterns, {
     cwd: definitionDir,
     gitignore: true, // use .gitignore
@@ -162,7 +162,7 @@ async function generateDocuments(options: GenerateDocsOptions): Promise<Generate
       frontmatter,
       config,
     };
-    const schema = resolveSchema(resolveSchemaOptions);
+    const schema = await resolveSchema(resolveSchemaOptions);
     if (schema) {
       const parsed = await schema.safeParseAsync(frontmatter); // Use `safeParseAsync` to allow async transforms
       if (parsed.success) {

--- a/packages/markdownlayer/src/remark/headings.ts
+++ b/packages/markdownlayer/src/remark/headings.ts
@@ -1,9 +1,7 @@
 // inspired by Docusaurus
 // https://github.com/facebook/docusaurus/blob/5baa68bea013c30e5b2ad2e166b0252344c0baab/packages/docusaurus-mdx-loader/src/remark/headings/index.ts
 
-import { slug as githubSlug } from 'github-slugger';
 import type { Heading, Text } from 'mdast';
-import { toString } from 'mdast-util-to-string';
 import type { Transformer } from 'unified';
 import { visit } from 'unist-util-visit';
 
@@ -34,7 +32,10 @@ export function parseMarkdownHeadingId(heading: string): {
 }
 
 export default function remarkHeadings(): Transformer {
-  return (root) => {
+  return async (root) => {
+    const { slug: githubSlug } = await import('github-slugger');
+    const { toString } = await import('mdast-util-to-string');
+
     visit(root, 'heading', (headingNode: Heading) => {
       const data = headingNode.data ?? (headingNode.data = {});
       const properties = (data.hProperties || (data.hProperties = {})) as {

--- a/packages/markdownlayer/src/schemas/resolve.ts
+++ b/packages/markdownlayer/src/schemas/resolve.ts
@@ -4,7 +4,7 @@ import { type GitParams, git } from './git';
 import { type IdOptions, id } from './id';
 import { type ImageParams, image } from './image';
 import { type ReadingTimeParams, readtime } from './read-time';
-import { type SlugParams, slug } from './slug';
+import { type SlugParams, generateDefault as generateDefaultSlug, slug } from './slug';
 import { toc } from './toc';
 
 export type SchemaContext = {
@@ -71,7 +71,7 @@ export type ResolveSchemaOptions = Pick<DocumentDefinition, 'schema'> & {
   frontmatter: Record<string, unknown>;
 };
 
-export function resolveSchema({
+export async function resolveSchema({
   type,
   schema,
 
@@ -82,13 +82,15 @@ export function resolveSchema({
   config,
 }: ResolveSchemaOptions) {
   if (typeof schema === 'function') {
+    const defaultSlugValue = await generateDefaultSlug({ type, path, config });
+
     schema = schema({
       body: (params: BodyParams = {}) => body({ ...params, path, contents, frontmatter, config }),
       git: (params: GitParams = {}) => git({ ...params, path }),
       id: (params: IdOptions = {}) => id({ ...params, type, path, config }),
       image: (params: ImageParams = {}) => image({ ...params, path, config }),
       readtime: (params: ReadingTimeParams = {}) => readtime({ ...params, contents }),
-      slug: (params: SlugParams = {}) => slug({ ...params, type, path, config }),
+      slug: (params: SlugParams = {}) => slug({ ...params, type, path, defaultValue: defaultSlugValue, config }),
       toc: () => toc({ contents }),
     });
   }

--- a/packages/markdownlayer/src/schemas/slug.test.ts
+++ b/packages/markdownlayer/src/schemas/slug.test.ts
@@ -26,6 +26,7 @@ describe('slug', () => {
       default: true,
       type: 'test',
       path: '/Users/mike/Documents/markdownlayer/examples/starter/src/content/test/test.md',
+      defaultValue: 'test',
       config: mockConfig,
     });
 
@@ -38,6 +39,7 @@ describe('slug', () => {
       default: false,
       type: 'test',
       path: '/Users/mike/Documents/markdownlayer/examples/starter/src/content/test/test.md',
+      defaultValue: 'test',
       config: mockConfig,
     });
 
@@ -50,6 +52,7 @@ describe('slug', () => {
       min: 3,
       type: 'test',
       path: '/Users/mike/Documents/markdownlayer/examples/starter/src/content/test/test.md',
+      defaultValue: 'test',
       config: mockConfig,
     });
 
@@ -62,6 +65,7 @@ describe('slug', () => {
       min: 0,
       type: 'test',
       path: '/Users/mike/Documents/markdownlayer/examples/starter/src/content/test/test.md',
+      defaultValue: 'test',
       config: mockConfig,
     });
 
@@ -73,6 +77,7 @@ describe('slug', () => {
       reserved: ['reserved-slug'],
       type: 'test',
       path: '/Users/mike/Documents/markdownlayer/examples/starter/src/content/test/test.md',
+      defaultValue: 'test',
       config: mockConfig,
     });
     expect(() => schema.parse('Invalid Slug!')).toThrow('Invalid slug');
@@ -83,6 +88,7 @@ describe('slug', () => {
       reserved: ['reserved-slug'],
       type: 'test',
       path: '/Users/mike/Documents/markdownlayer/examples/starter/src/content/test/test.md',
+      defaultValue: 'test',
       config: mockConfig,
     });
 
@@ -93,6 +99,7 @@ describe('slug', () => {
     const schema = slug({
       type: 'test',
       path: '/Users/mike/Documents/markdownlayer/examples/starter/src/content/test/test.md',
+      defaultValue: 'test',
       config: mockConfig,
     });
 
@@ -104,6 +111,7 @@ describe('slug', () => {
     const schema = slug({
       type: 'test',
       path: '/Users/mike/Documents/markdownlayer/examples/starter/src/content/test/test.md',
+      defaultValue: 'test',
       config: mockConfig,
     });
 
@@ -116,20 +124,20 @@ describe('slug', () => {
 });
 
 describe('generate', () => {
-  it('should generate slug from filename', () => {
-    expect(generate('my-first-post.md')).toBe('my-first-post');
+  it('should generate slug from filename', async () => {
+    expect(await generate('my-first-post.md')).toBe('my-first-post');
   });
 
-  it('should handle index file', () => {
-    expect(generate('index.md')).toBe('');
+  it('should handle index file', async () => {
+    expect(await generate('index.md')).toBe('');
   });
 
-  it('should handle nested directory', () => {
-    expect(generate('en/posts/my-first-post.md')).toEqual('en/posts/my-first-post');
+  it('should handle nested directory', async () => {
+    expect(await generate('en/posts/my-first-post.md')).toEqual('en/posts/my-first-post');
   });
 
-  it('should handle nested directory with index file', () => {
-    expect(generate('en/docs/index.md')).toBe('en/docs');
+  it('should handle nested directory with index file', async () => {
+    expect(await generate('en/docs/index.md')).toBe('en/docs');
   });
 });
 

--- a/packages/markdownlayer/src/schemas/toc.test.ts
+++ b/packages/markdownlayer/src/schemas/toc.test.ts
@@ -2,14 +2,14 @@ import { describe, expect, it } from 'vitest';
 import { toc } from './toc';
 
 describe('toc', () => {
-  it('should generate a table of contents from markdown content', () => {
+  it('should generate a table of contents from markdown content', async () => {
     const contents = `
 # Header 1
 ## Header 2
 ### Header 3
 `;
 
-    const result = toc({ contents }).parse({});
+    const result = await toc({ contents }).parseAsync({});
     expect(result).toEqual([
       { level: 1, value: 'Header 1', id: 'header-1', url: '#header-1' },
       { level: 2, value: 'Header 2', id: 'header-2', url: '#header-2' },
@@ -17,17 +17,17 @@ describe('toc', () => {
     ]);
   });
 
-  it('should handle markdown content with no headers', () => {
+  it('should handle markdown content with no headers', async () => {
     const contents = `
 This is a paragraph.
 Another paragraph.
 `;
 
-    const result = toc({ contents }).parse({});
+    const result = await toc({ contents }).parseAsync({});
     expect(result).toEqual([]);
   });
 
-  it('should handle markdown content with mixed content', () => {
+  it('should handle markdown content with mixed content', async () => {
     const contents = `
 # Header 1
 This is a paragraph.
@@ -36,7 +36,7 @@ Another paragraph.
 ### Header 3
 `;
 
-    const result = toc({ contents }).parse({});
+    const result = await toc({ contents }).parseAsync({});
     expect(result).toEqual([
       { level: 1, value: 'Header 1', id: 'header-1', url: '#header-1' },
       { level: 2, value: 'Header 2', id: 'header-2', url: '#header-2' },
@@ -44,14 +44,14 @@ Another paragraph.
     ]);
   });
 
-  it('should handle markdown content with special characters in headers', () => {
+  it('should handle markdown content with special characters in headers', async () => {
     const contents = `
 # Header 1!
 ## Header 2@
 ### Header 3#
 `;
 
-    const result = toc({ contents }).parse({});
+    const result = await toc({ contents }).parseAsync({});
     expect(result).toEqual([
       { level: 1, value: 'Header 1!', id: 'header-1', url: '#header-1' },
       { level: 2, value: 'Header 2@', id: 'header-2', url: '#header-2' },

--- a/packages/markdownlayer/src/schemas/toc.ts
+++ b/packages/markdownlayer/src/schemas/toc.ts
@@ -1,4 +1,3 @@
-import { slug as githubSlug } from 'github-slugger';
 import { custom } from 'zod';
 import type { TocItem } from '../types';
 
@@ -13,7 +12,9 @@ const regXHeader = /\n(?<flag>#{1,6})\s+(?<content>.+)/g;
  * @returns A Zod object representing table of contents data.
  */
 export function toc({ contents }: { contents: string }) {
-  return custom().transform<TocItem[]>(() => {
+  return custom().transform<TocItem[]>(async () => {
+    const { slug: githubSlug } = await import('github-slugger');
+
     return Array.from(contents.matchAll(regXHeader)).map(({ groups }) => {
       const { flag, content } = groups!;
       // Note: using `slug` instead of `new Slugger()` means no slug deduplication.

--- a/packages/markdownlayer/tsup.config.ts
+++ b/packages/markdownlayer/tsup.config.ts
@@ -11,7 +11,7 @@ export default defineConfig((options: Options) => ({
     // Remark plugins
     'src/remark/index.ts',
   ],
-  format: ['esm'],
+  format: ['esm', 'cjs'],
   dts: true,
   minify: false,
   clean: true,


### PR DESCRIPTION
This solves some issues in NextJS config files.
Setting `"type": "module"` in applications is no longer required.